### PR TITLE
WL-2475: Assignments not retrieving Turnitin Originality reports

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinAccountConnection.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinAccountConnection.java
@@ -304,8 +304,10 @@ public class TurnitinAccountConnection {
 				else {
 					Set<String> instIds = getActiveInstructorIds(INST_ROLE,
 							site);
-					if (instIds.size() > 0) {
-						inst = userDirectoryService.getUser((String) instIds.toArray()[0]);
+					for(String instructorId:instIds){
+						inst = userDirectoryService.getUser(instructorId);
+						if(inst.getEmail() != null && inst.getFirstName() != null && inst.getLastName() != null)
+							break;
 					}
 				}
 			} catch (IdUnusedException e) {


### PR DESCRIPTION
Due to an 'instructor' not having names set (or presumably email)
