### PR TITLE
WL-2475: Assignments not retrieving Turnitin Originality reports

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinAccountConnection.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinAccountConnection.java
@@ -337,7 +337,9 @@ public class TurnitinAccountConnection {
 		Set<String> ret =  new HashSet<String>();
 		for (int i = 0; i < activeUsers.size(); i++) {
 			User user = activeUsers.get(i);
-			ret.add(user.getId());
+			//Checks that the user has the required attributes to be a registered instructor.
+			if(user.getEmail() != null && user.getFirstName() != null && user.getLastName() != null)
+				ret.add(user.getId());
 		}
 
 		return ret;


### PR DESCRIPTION
Reverts the previous change (that was on only one method) and apply the fix on `getActiveInstructorIds()`
