### PR TITLE
Revert "WL-1136: filter the titles of assignments before sending to Turn..."

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -837,7 +837,6 @@ private List<ContentReviewItem> getItemsByContentId(String contentId) {
 					ent.getClass().getMethod("getTitle").invoke(ent).toString();
 				log.debug("Got reflected assignemment title from entity " + title);
 				togo = URLDecoder.decode(title,"UTF-8");
-				togo=togo.replaceAll("\\W+","");
 
 			} catch (Exception e) {
 				e.printStackTrace();


### PR DESCRIPTION
It seems that Turnitin now handles complicated titles. After multiple tests, it seems that this fix isn't useful anymore.
