### PR TITLE
WL-2962 Don't fail on partial users when syncing.

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinRosterSync.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinRosterSync.java
@@ -255,7 +255,7 @@ public class TurnitinRosterSync {
 
 		Map params = getUserMap(user);
 
-	    params.putAll(TurnitinAPIUtil.packMap(turnitinConn.getBaseTIIOptions(),
+		params.putAll(TurnitinAPIUtil.packMap(turnitinConn.getBaseTIIOptions(),
 				"cid", cid,
 				"cpw", cpw,
 				"ctl", ctl,


### PR DESCRIPTION
If an instructor can be found (got a user object) but some details are missing don't fail the sync. This stops some sites running away when a user no longer fully exists in LDAP and needs to have their role switched.
