### PR TITLE
WL-3081 Don't attempt to sync null users.

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinRosterSync.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinRosterSync.java
@@ -305,6 +305,9 @@ public class TurnitinRosterSync {
 	 * @throws SubmissionException If validation of any of the fields fails.
 	 */
 	public Map<String,String> getUserMap(User user) throws SubmissionException {
+		if (user == null) {
+			throw new SubmissionException("Can't get details for null user");
+		}
 		Map<String, String> userMap = new HashMap<String, String>();
 		String uem = turnitinReviewServiceImpl.getEmail(user);
 		String uid = user.getId();


### PR DESCRIPTION
When we are trying to get details of a deleted user we should just give up early rather than blowing up in a logging statement.
