### PR TITLE
WL-4218 Use a chaining advisor (OR) for Turnitin.

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/ChainedPropertyAdvisor.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/ChainedPropertyAdvisor.java
@@ -1,0 +1,49 @@
+package org.sakaiproject.contentreview.impl.advisors;
+
+import org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor;
+import org.sakaiproject.site.api.Site;
+
+import java.util.List;
+
+/**
+ * This checks all the advisors in the list and if any say <code>true</code> then we return <code>true</code>.
+ * Basically is does a OR on all the advisors.
+ */
+public class ChainedPropertyAdvisor implements ContentReviewSiteAdvisor {
+
+    private List<ContentReviewSiteAdvisor> advisors;
+
+    public void setAdvisors(List<ContentReviewSiteAdvisor> advisors) {
+        this.advisors = advisors;
+    }
+
+    @Override
+    public boolean siteCanUseReviewService(Site site) {
+        for(ContentReviewSiteAdvisor advisor : advisors) {
+            if (advisor.siteCanUseReviewService(site)){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean siteCanUseLTIReviewService(Site site) {
+        for(ContentReviewSiteAdvisor advisor: advisors) {
+            if (advisor.siteCanUseLTIReviewService(site)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean siteCanUseLTIDirectSubmission(Site site) {
+        for(ContentReviewSiteAdvisor advisor: advisors) {
+            if (advisor.siteCanUseLTIDirectSubmission(site)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/contentreview-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/contentreview-impl/pack/src/webapp/WEB-INF/components.xml
@@ -67,27 +67,46 @@
     </bean>-->
 
 	<!--  Uncomment this to use a site property to define which sites use c-r -->
-	
-	<bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" class="org.sakaiproject.contentreview.impl.advisors.SitePropertyAdvisor">
-		<property name="siteProperty"><value>useContentReviewService</value></property>
-		<property name="siteLTIProperty"><value>useContentReviewLTIService</value></property>
-		<property name="siteDirectSubmissionProperty"><value>useContentReviewDirectSubmission</value></property>
-	</bean>
 
-	<!-- uncomment this bean to make cr available to only sites of the type course -->
-	<!--
-		<bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" class="org.sakaiproject.contentreview.impl.advisors.SiteCourseTypeAdvisor">
-		</bean>
-	-->
-	
-	<!--  Uncomment this to use a global property to define if every site uses c-r -->
-	<!--<bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" class="org.sakaiproject.contentreview.impl.advisors.GlobalPropertyAdvisor">
-		<property name="tiiProperty"><value>assignment.useContentReview</value></property>
-		<property name="tiiLTIProperty"><value>assignment.useContentReviewLTI</value></property>
-		<property name="tiiDirectSubmissionProperty"><value>assignment.useContentReviewDirect</value></property>
-		<property name="serverConfigurationService"
-			ref="org.sakaiproject.component.api.ServerConfigurationService" />
-	</bean>-->
+	<bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor"
+		  class="org.sakaiproject.contentreview.impl.advisors.ChainedPropertyAdvisor">
+		<property name="advisors">
+			<list>
+				<bean class="org.sakaiproject.contentreview.impl.advisors.SitePropertyAdvisor">
+					<property name="siteProperty">
+						<value>useContentReviewService</value>
+					</property>
+					<property name="siteLTIProperty">
+						<value>useContentReviewLTIService</value>
+					</property>
+					<property name="siteDirectSubmissionProperty">
+						<value>useContentReviewDirectSubmission</value>
+					</property>
+				</bean>
+
+				<!-- uncomment this bean to make cr available to only sites of the type course -->
+				<!--
+                    <bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" class="org.sakaiproject.contentreview.impl.advisors.SiteCourseTypeAdvisor">
+                    </bean>
+                -->
+
+				<!--  Uncomment this to use a global property to define if every site uses c-r -->
+				<bean class="org.sakaiproject.contentreview.impl.advisors.GlobalPropertyAdvisor">
+					<property name="tiiProperty">
+						<value>assignment.useContentReview</value>
+					</property>
+					<property name="tiiLTIProperty">
+						<value>assignment.useContentReviewLTI</value>
+					</property>
+					<property name="tiiDirectSubmissionProperty">
+						<value>assignment.useContentReviewDirect</value>
+					</property>
+					<property name="serverConfigurationService"
+							  ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+				</bean>
+			</list>
+		</property>
+	</bean>
 
 
 	<!-- QueuProcessing jobs -->


### PR DESCRIPTION
This allows us to turn off options in the main config but turn them back on again on a per site basis.