### PR TITLE
WL-4329 Assignment creation LTI launch HTTP 200

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinLTIUtil.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinLTIUtil.java
@@ -152,6 +152,9 @@ public class TurnitinLTIUtil {
 						log.debug("Breakdown originality values: " + breakdown.toString());//TODO when should this be showed?
 					}
 					return score;
+				} else if (type == BASIC_ASSIGNMENT) {
+					// If we get a 200 back and don't want more information it's ok.
+					return 1;
 				}
 			} else if(statusCode == 302){
 				log.debug("Successful call: " + defUrl);


### PR DESCRIPTION
When creating an assignment the returned HTTP code is 200, this isn’t currently handled and so an error is shown to the user indicating that the launch failed (wrongly). This adds support for handling the 200 code when creating an assignment.

This is used when useContentReviewLTI is set to true.